### PR TITLE
Allow optional randomness in Geometry

### DIFF
--- a/app/Graphics/Ray.hs
+++ b/app/Graphics/Ray.hs
@@ -17,6 +17,7 @@ import Graphics.Pixel.ColorSpace (SRGB, Linearity(Linear, NonLinear))
 import qualified Graphics.Pixel.ColorSpace as C
 import Control.Monad.State (State, state, evalState)
 import Control.Monad (replicateM)
+import Data.Functor.Identity (Identity, runIdentity)
 
 data CameraSettings = CameraSettings
   { cs_center :: Point3
@@ -48,7 +49,7 @@ defaultCameraSettings = CameraSettings
   }
 
 -- TODO: modify to return seed
-raytrace :: CameraSettings -> Geometry Material -> StdGen -> A.Matrix D Color
+raytrace :: CameraSettings -> Geometry Identity Material -> StdGen -> A.Matrix D Color
 raytrace (CameraSettings {..}) (Geometry _ hitWorld) seed = let
   imageHeight = ceiling (fromIntegral cs_imageWidth / cs_aspectRatio)
   viewportHeight = cs_focusDist * tan (cs_vfov / 2) * 2
@@ -90,7 +91,7 @@ raytrace (CameraSettings {..}) (Geometry _ hitWorld) seed = let
   rayColor depth ray
     | depth <= 0 = pure zero
     | otherwise =
-    hitWorld ray (0.0001, infinity) >>= \case
+    case runIdentity (hitWorld ray (0.0001, infinity)) of
       Nothing -> pure (cs_background ray)
       Just (hit, Material mat) -> 
         mat ray hit >>= \case

--- a/app/Graphics/Ray.hs
+++ b/app/Graphics/Ray.hs
@@ -90,7 +90,7 @@ raytrace (CameraSettings {..}) (Geometry _ hitWorld) seed = let
   rayColor depth ray
     | depth <= 0 = pure zero
     | otherwise =
-    case hitWorld ray (0.0001, infinity) of
+    hitWorld ray (0.0001, infinity) >>= \case
       Nothing -> pure (cs_background ray)
       Just (hit, Material mat) -> 
         mat ray hit >>= \case

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -231,6 +231,6 @@ main :: IO ()
 main = do
   putStrLn "branch: monadic"
   let red = lambertian (constantTexture (V3 1 0 0))
-  let world = red <$ sphere (V3 0 0 (-1)) 0.5
+  let world = transform (translate (V3 0 0 (-1))) (red <$ sphere (V3 0 0 0) 0.5)
   let settings = defaultCameraSettings { cs_samplesPerPixel = 5000 }
   writeImage "test_image.png" . raytrace settings world =<< newStdGen

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -232,5 +232,5 @@ main = do
   putStrLn "branch: monadic"
   let red = lambertian (constantTexture (V3 1 0 0))
   let world = red <$ sphere (V3 0 0 (-1)) 0.5
-  let settings = defaultCameraSettings
+  let settings = defaultCameraSettings { cs_samplesPerPixel = 5000 }
   writeImage "test_image.png" . raytrace settings world =<< newStdGen

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -16,6 +16,7 @@ import Control.Monad.State (State, runState, state)
 import Control.Monad (forM)
 import Control.Applicative (liftA2)
 import Data.Massiv.Array (Matrix, U)
+import Data.Functor.Identity (Identity)
 
 sky :: Ray -> Color
 sky (Ray _ (normalize -> V3 _ y _)) = 
@@ -158,7 +159,7 @@ demo1 = let
     , materialMirror <$ sphere (V3 4 1 0) 1
     ]
 
-  genWorld :: State StdGen (Geometry Material)
+  genWorld :: State StdGen (Geometry Identity Material)
   genWorld = do
     fmap (bvhTree . autoTree . (bigSpheres ++) . concat) $ forM (liftA2 (,) [-11..10] [-11..10]) $ \(a, b) -> do
       offsetX <- state (randomR (0, 0.9))
@@ -196,6 +197,7 @@ demo1 = let
   let (world, seed') = runState genWorld seed
   writeImageRTW "test_image.png" $ raytrace settings world seed'
 
+-- TODO: make sure this completes in under 2:00
 cornellBox :: IO ()
 cornellBox = let
   red = lambertian (constantTexture (V3 0.65 0.05 0.05))
@@ -228,9 +230,4 @@ cornellBox = let
   in writeImageRTW "test_image.png" . raytrace settings world =<< newStdGen
 
 main :: IO ()
-main = do
-  putStrLn "branch: monadic"
-  let red = lambertian (constantTexture (V3 1 0 0))
-  let world = transform (translate (V3 0 0 (-1))) (red <$ sphere (V3 0 0 0) 0.5)
-  let settings = defaultCameraSettings { cs_samplesPerPixel = 5000 }
-  writeImage "test_image.png" . raytrace settings world =<< newStdGen
+main = cornellBox

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -228,4 +228,9 @@ cornellBox = let
   in writeImageRTW "test_image.png" . raytrace settings world =<< newStdGen
 
 main :: IO ()
-main = cornellBox
+main = do
+  putStrLn "branch: monadic"
+  let red = lambertian (constantTexture (V3 1 0 0))
+  let world = red <$ sphere (V3 0 0 (-1)) 0.5
+  let settings = defaultCameraSettings
+  writeImage "test_image.png" . raytrace settings world =<< newStdGen

--- a/raytrace.cabal
+++ b/raytrace.cabal
@@ -64,7 +64,7 @@ executable raytrace
     -- other-extensions:
 
     -- Other library packages from which modules are imported.
-    build-depends:    base ^>=4.17.2.1, linear, massiv, massiv-io, Color, random >= 1.3.0, mtl, transformers
+    build-depends:    base ^>=4.17.2.1, linear, massiv, massiv-io, Color, random >= 1.3.0, mtl
 
     -- Directories containing source files.
     hs-source-dirs:   app

--- a/raytrace.cabal
+++ b/raytrace.cabal
@@ -64,7 +64,7 @@ executable raytrace
     -- other-extensions:
 
     -- Other library packages from which modules are imported.
-    build-depends:    base ^>=4.17.2.1, linear, massiv, massiv-io, Color, random >= 1.3.0, mtl
+    build-depends:    base ^>=4.17.2.1, linear, massiv, massiv-io, Color, random >= 1.3.0, mtl, transformers
 
     -- Directories containing source files.
     hs-source-dirs:   app


### PR DESCRIPTION
Replace
```haskell
data Geometry a = Geometry Box (Ray -> Interval -> Maybe (HitRecord, a))
```
with
```haskell
data Geometry m a = Geometry Box (Ray -> Interval -> m (Maybe (HitRecord, a)))
```
and everything that entails. The `raytrace` function still requires that `m` be `Identity`, however.